### PR TITLE
fix(api): transfer-decode message bodies and render single-part text/html

### DIFF
--- a/handlers/api/collectbodies_test.go
+++ b/handlers/api/collectbodies_test.go
@@ -1,0 +1,189 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"lilmail/models"
+)
+
+// collect is a helper mirroring how processMessage invokes collectBodies on a
+// parsed net/mail message: top-level headers, then the raw body reader.
+func collect(t *testing.T, contentType, cte, disposition, body string) models.Email {
+	t.Helper()
+	var email models.Email
+	collectBodies(strings.NewReader(body), contentType, cte, disposition, &email, 0)
+	return email
+}
+
+// A single-part text/html message — the exact shape of Anthropic's
+// "Secure link to log in to Claude.ai" mail — must land in HTML, not Body.
+// The viewer template renders HTML in an iframe and only falls back to
+// linkified plain text, so misfiling this shows the reader raw HTML source.
+func TestSinglePartHTMLQuotedPrintable(t *testing.T) {
+	got := collect(t, "text/html; charset=us-ascii", "quoted-printable", "",
+		"<p>Click =E2=80=94 <a href=3D\"https://claude.ai/magic-link\">here</a>=\r\n to log in</p>")
+
+	if got.Body != "" {
+		t.Errorf("Body should stay empty for a text/html message, got %q", got.Body)
+	}
+	want := `<p>Click — <a href="https://claude.ai/magic-link">here</a> to log in</p>`
+	if got.HTML != want {
+		t.Errorf("HTML not transfer-decoded\n got: %q\nwant: %q", got.HTML, want)
+	}
+}
+
+func TestSinglePartPlainBase64(t *testing.T) {
+	// base64("我们将于 2026 年") — wrapped, as transports emit it.
+	got := collect(t, "text/plain; charset=utf-8", "base64", "",
+		"5oiR5Lus5bCG5LqOIDIwMjYg5bm0\r\n")
+	if got.HTML != "" {
+		t.Errorf("HTML should stay empty, got %q", got.HTML)
+	}
+	if got.Body != "我们将于 2026 年" {
+		t.Errorf("base64 body not decoded: %q", got.Body)
+	}
+}
+
+func TestMultipartAlternativeBase64Plain(t *testing.T) {
+	body := "--b1\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: base64\r\n\r\n" +
+		"aGVsbG8gcGxhaW4=\r\n" +
+		"--b1\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n\r\n" +
+		"<b>hello html</b>\r\n" +
+		"--b1--\r\n"
+	got := collect(t, `multipart/alternative; boundary="b1"`, "", "", body)
+
+	if got.Body != "hello plain" {
+		t.Errorf("base64 part not decoded: %q", got.Body)
+	}
+	if !strings.Contains(got.HTML, "<b>hello html</b>") {
+		t.Errorf("html part missing: %q", got.HTML)
+	}
+}
+
+// multipart/mixed › multipart/alternative — the old code only looked one level
+// deep, so the nested container matched neither text/plain nor text/html and
+// the message rendered blank.
+func TestNestedMultipartRecursion(t *testing.T) {
+	body := "--outer\r\n" +
+		"Content-Type: multipart/alternative; boundary=\"inner\"\r\n\r\n" +
+		"--inner\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"nested plain\r\n" +
+		"--inner\r\n" +
+		"Content-Type: text/html\r\n\r\n" +
+		"<i>nested html</i>\r\n" +
+		"--inner--\r\n" +
+		"--outer--\r\n"
+	got := collect(t, `multipart/mixed; boundary="outer"`, "", "", body)
+
+	if !strings.Contains(got.Body, "nested plain") {
+		t.Errorf("nested plain not found: %q", got.Body)
+	}
+	if !strings.Contains(got.HTML, "<i>nested html</i>") {
+		t.Errorf("nested html not found: %q", got.HTML)
+	}
+}
+
+// A text/plain attachment must not become the message body.
+func TestAttachmentDoesNotClobberBody(t *testing.T) {
+	body := "--b2\r\n" +
+		"Content-Type: text/plain\r\n" +
+		"Content-Disposition: attachment; filename=\"notes.txt\"\r\n\r\n" +
+		"ATTACHED FILE CONTENT\r\n" +
+		"--b2\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"the real body\r\n" +
+		"--b2--\r\n"
+	got := collect(t, `multipart/mixed; boundary="b2"`, "", "", body)
+
+	if strings.Contains(got.Body, "ATTACHED") {
+		t.Errorf("attachment leaked into body: %q", got.Body)
+	}
+	if !strings.Contains(got.Body, "the real body") {
+		t.Errorf("real body lost: %q", got.Body)
+	}
+}
+
+// The list preview slices the first 512 bytes of a body, so decoding must
+// survive input cut mid-quantum instead of falling back to raw gibberish.
+func TestDecodeTransferBytesToleratesTruncation(t *testing.T) {
+	full := "aGVsbG8gd29ybGQsIHRoaXMgaXMgYSBsb25nZXIgbGluZQ==" // "hello world, this is a longer line"
+	truncated := full[:20]                                     // not a multiple of 4
+	got := string(decodeTransferBytes([]byte(truncated), "base64"))
+	if !strings.HasPrefix(got, "hello world") {
+		t.Errorf("truncated base64 should decode its clean prefix, got %q", got)
+	}
+
+	qp := "caf=C3=A9 and =E2=80" // trailing escape cut in half
+	got = string(decodeTransferBytes([]byte(qp), "quoted-printable"))
+	if !strings.HasPrefix(got, "café") {
+		t.Errorf("truncated quoted-printable should keep its prefix, got %q", got)
+	}
+}
+
+// A marketing mail's preview must not be its CSS reset. This is the literal
+// text Anthropic's and Tripo's mail produced in the message list.
+func TestStripHTMLSkipsStyleAndScript(t *testing.T) {
+	markup := `<head><style type="text/css">#outlook a { padding:0; } body { margin:0; }</style></head>` +
+		`<body><script>var x = 1 < 2;</script><p>Your login link is ready</p></body>`
+	got := stripHTML(markup)
+
+	if strings.Contains(got, "#outlook") || strings.Contains(got, "padding") {
+		t.Errorf("CSS leaked into preview: %q", got)
+	}
+	if strings.Contains(got, "var x") {
+		t.Errorf("script leaked into preview: %q", got)
+	}
+	if !strings.Contains(got, "Your login link is ready") {
+		t.Errorf("real text lost: %q", got)
+	}
+}
+
+func TestStripHTMLEntitiesAndZeroWidth(t *testing.T) {
+	got := stripHTML("<p>Caf&eacute; &amp; bar\u200c\u200b\ufeff</p>")
+	if got != "Café & bar" {
+		t.Errorf("entities/zero-width not handled: %q", got)
+	}
+}
+
+// <styles> is not a <style> element; its text must survive.
+func TestStripHTMLDoesNotEatLookalikeTag(t *testing.T) {
+	got := stripHTML("<styles-x>kept</styles-x>")
+	if got != "kept" {
+		t.Errorf("lookalike tag ate content: %q", got)
+	}
+}
+
+// Outlook conditional comments carry markup, not prose: their <o:PixelsPerInch>
+// value was leaking into previews as a stray "96".
+func TestStripHTMLSkipsComments(t *testing.T) {
+	markup := `<!--[if mso]><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96` +
+		`</o:PixelsPerInch></o:OfficeDocumentSettings></xml><![endif]-->` +
+		`<p>Let's get you signed in</p>`
+	got := stripHTML(markup)
+	if strings.Contains(got, "96") {
+		t.Errorf("conditional comment leaked into preview: %q", got)
+	}
+	if !strings.HasPrefix(got, "Let's get you signed in") {
+		t.Errorf("real text lost or displaced: %q", got)
+	}
+}
+
+// The 4096-byte preview window overruns the first part of a multipart message
+// into the next MIME boundary; a base64 part must still decode up to that point
+// instead of failing whole and showing the reader raw base64.
+func TestDecodeBase64StopsAtMIMEBoundary(t *testing.T) {
+	// base64("我们将于 2026 年") followed by the next boundary and part headers.
+	chunk := "5oiR5Lus5bCG5LqOIDIwMjYg5bm0\r\n--b1\r\nContent-Type: text/html\r\n"
+	got := string(decodeTransferBytes([]byte(chunk), "base64"))
+	if !strings.HasPrefix(got, "我们将于 2026 年") {
+		t.Errorf("base64 prefix not decoded before boundary: %q", got)
+	}
+	if strings.Contains(got, "Content-Type") {
+		t.Errorf("boundary headers leaked into decoded text: %q", got)
+	}
+}

--- a/handlers/api/email.go
+++ b/handlers/api/email.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	stdhtml "html"
 	"io"
 	"lilmail/models"
 	"log"
@@ -23,12 +24,14 @@ import (
 var reMessageID = regexp.MustCompile(`<[^>]+>`)
 
 // previewSection is the IMAP body section used to fetch a small text snippet
-// for the message list. BODY.PEEK[TEXT]<0.512> fetches the first 512 bytes of
-// the message text body without implicitly setting the \Seen flag.
+// for the message list. BODY.PEEK[TEXT]<0.4096> fetches the head of the message
+// text body without implicitly setting the \Seen flag. 4096 rather than 512
+// because an HTML mail opens with a <style> block that routinely runs past the
+// first kilobyte, leaving no prose in a shorter window.
 var previewSection = &imap.BodySectionName{
 	BodyPartName: imap.BodyPartName{Specifier: imap.TextSpecifier},
 	Peek:         true,
-	Partial:      []int{0, 512},
+	Partial:      []int{0, 4096},
 }
 
 // referencesSection fetches the References header line without marking seen.
@@ -156,6 +159,9 @@ func (c *Client) processListMessage(msg *imap.Message, folderName string) (model
 			} else if idx := strings.Index(text, "\n\n"); idx >= 0 {
 				text = text[idx+2:]
 			}
+			// These bytes are still transfer-encoded: base64 shows up as gibberish
+			// and quoted-printable leaks "=E2=80=94" and "=" soft line breaks.
+			text = string(decodeTransferBytes([]byte(text), previewEncoding(msg.BodyStructure)))
 			text = stripHTML(text)
 			email.Preview = createPreview(text)
 		}
@@ -624,41 +630,14 @@ func (c *Client) processMessage(msg *imap.Message, folderName string) (models.Em
 			email.Unsubscribe = ParseUnsubscribe(lu, m.Header["List-Unsubscribe-Post"])
 		}
 
-		// Handle multipart messages
-		contentType := m.Header.Get("Content-Type")
-		mediaType, params, err := mime.ParseMediaType(contentType)
-		if err == nil && strings.HasPrefix(mediaType, "multipart/") {
-			mr := multipart.NewReader(m.Body, params["boundary"])
-			for {
-				p, err := mr.NextPart()
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
-					continue
-				}
-
-				// Read the part
-				partData, err := io.ReadAll(p)
-				if err != nil {
-					continue
-				}
-
-				partType := p.Header.Get("Content-Type")
-				switch {
-				case strings.Contains(partType, "text/plain"):
-					email.Body = string(partData)
-				case strings.Contains(partType, "text/html"):
-					email.HTML = string(partData)
-				}
-			}
-		} else {
-			// Handle non-multipart messages
-			bodyData, err := io.ReadAll(m.Body)
-			if err == nil {
-				email.Body = string(bodyData)
-			}
-		}
+		collectBodies(
+			m.Body,
+			m.Header.Get("Content-Type"),
+			m.Header.Get("Content-Transfer-Encoding"),
+			m.Header.Get("Content-Disposition"),
+			&email,
+			0,
+		)
 
 		// Add preview after all content is processed
 		if email.Body != "" {
@@ -690,6 +669,129 @@ func (c *Client) processMessage(msg *imap.Message, folderName string) (models.Em
 	}
 
 	return email, nil
+}
+
+// decodeTransferBytes reverses a Content-Transfer-Encoding over a byte slice.
+// Unknown or absent encodings (7bit/8bit/binary) pass through untouched.
+// mime/multipart already decodes quoted-printable parts and strips the header,
+// so that case here only fires for non-multipart messages, which net/mail
+// leaves raw. Unlike the streaming decodeTransfer below it tolerates truncated
+// input — the message-list preview decodes only
+// the first 512 bytes of a body — by keeping whatever decoded cleanly before
+// the cut rather than discarding the whole chunk.
+func decodeTransferBytes(data []byte, enc string) []byte {
+	switch strings.ToLower(strings.TrimSpace(enc)) {
+	case "base64":
+		// Transport base64 is line-wrapped; the decoder rejects newlines.
+		clean := bytes.Map(func(r rune) rune {
+			if r == '\r' || r == '\n' {
+				return -1
+			}
+			return r
+		}, data)
+		// The preview window can run past this part into the next MIME boundary,
+		// so stop at the first byte outside the alphabet rather than failing the
+		// whole chunk, then drop the trailing partial quantum.
+		clean = clean[:base64PrefixLen(clean)]
+		clean = clean[:len(clean)-len(clean)%4]
+		if dec, err := base64.StdEncoding.DecodeString(string(clean)); err == nil {
+			return dec
+		}
+	case "quoted-printable":
+		var out bytes.Buffer
+		// CopyN-style drain: a decode error mid-stream still leaves the prefix.
+		if _, err := io.Copy(&out, quotedprintable.NewReader(bytes.NewReader(data))); err == nil || out.Len() > 0 {
+			return out.Bytes()
+		}
+	}
+	return data
+}
+
+// base64PrefixLen reports the length of the leading run of standard base64
+// characters in b, i.e. where a decodable prefix stops.
+func base64PrefixLen(b []byte) int {
+	for i, c := range b {
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '+', c == '/', c == '=':
+		default:
+			return i
+		}
+	}
+	return len(b)
+}
+
+// previewEncoding reports the Content-Transfer-Encoding that applies to the
+// bytes IMAP returns for BODY[TEXT]: the message encoding for a single-part
+// message, or the first leaf part's for a multipart one (BODY[TEXT] hands back
+// the raw MIME body, whose first part is what the preview text is sliced from).
+func previewEncoding(bs *imap.BodyStructure) string {
+	if bs == nil {
+		return ""
+	}
+	if strings.EqualFold(bs.MIMEType, "multipart") {
+		if len(bs.Parts) == 0 {
+			return ""
+		}
+		return previewEncoding(bs.Parts[0])
+	}
+	return bs.Encoding
+}
+
+// collectBodies fills email.Body (text/plain) and email.HTML (text/html) from a
+// MIME tree, recursing through multipart containers and transfer-decoding each
+// leaf. The first non-empty part of each kind wins, so a multipart/alternative
+// keeps the plain part rather than letting a later sibling clobber it.
+//
+// A single-part text/html message must land in email.HTML, not email.Body — the
+// viewer template renders HTML in a sandboxed iframe and only falls back to
+// linkified plain text, so misfiling it shows the reader raw HTML source.
+func collectBodies(body io.Reader, contentType, cte, disposition string, email *models.Email, depth int) {
+	if depth > 10 {
+		return
+	}
+
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		// A missing or unparseable Content-Type defaults to text/plain (RFC 2045).
+		mediaType = "text/plain"
+	}
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		mr := multipart.NewReader(body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				return
+			}
+			collectBodies(
+				p,
+				p.Header.Get("Content-Type"),
+				p.Header.Get("Content-Transfer-Encoding"),
+				p.Header.Get("Content-Disposition"),
+				email,
+				depth+1,
+			)
+		}
+	}
+
+	// Attachments carry their own text; they must not become the body.
+	if disp, _, err := mime.ParseMediaType(disposition); err == nil && disp == "attachment" {
+		return
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return
+	}
+	data = decodeTransferBytes(data, cte)
+
+	switch {
+	case strings.HasPrefix(mediaType, "text/html") && email.HTML == "":
+		email.HTML = string(data)
+	case strings.HasPrefix(mediaType, "text/plain") && email.Body == "":
+		email.Body = string(data)
+	}
 }
 
 // extractCalendarPart walks a raw RFC 5322 message and returns the transfer-
@@ -757,22 +859,86 @@ func decodeTransfer(r io.Reader, enc string) io.Reader {
 }
 
 // Simple HTML tag stripping
-func stripHTML(html string) string {
+// stripHTML reduces an HTML body to the text a preview snippet should show.
+// Beyond dropping tags it skips <style>/<script> contents — otherwise a preview
+// of a marketing mail is just its CSS reset ("#outlook a { padding:0; }") — then
+// resolves entities and removes the zero-width characters senders pad their
+// preheader with.
+func stripHTML(markup string) string {
 	var builder strings.Builder
-	inTag := false
 
-	for _, r := range html {
-		switch {
-		case r == '<':
-			inTag = true
-		case r == '>':
-			inTag = false
-		case !inTag:
-			builder.WriteRune(r)
+	lower := strings.ToLower(markup)
+	for i := 0; i < len(markup); {
+		if markup[i] == '<' {
+			// Skip comments, including Outlook conditionals such as
+			// <!--[if mso]><o:PixelsPerInch>96</o:PixelsPerInch><![endif]-->,
+			// whose contents are markup rather than prose.
+			if strings.HasPrefix(markup[i:], "<!--") {
+				if end := strings.Index(markup[i+4:], "-->"); end >= 0 {
+					i += 4 + end + 3
+					continue
+				}
+				break
+			}
+			// Skip an entire <style>…</style> or <script>…</script> element.
+			if skipTo, ok := skipRawTextElement(lower, i); ok {
+				i = skipTo
+				continue
+			}
+			if end := strings.IndexByte(markup[i:], '>'); end >= 0 {
+				i += end + 1
+				continue
+			}
+			break // unterminated tag: nothing further is text
 		}
+		next := strings.IndexByte(markup[i:], '<')
+		if next < 0 {
+			builder.WriteString(markup[i:])
+			break
+		}
+		builder.WriteString(markup[i : i+next])
+		i += next
 	}
 
-	return strings.TrimSpace(builder.String())
+	text := stdhtml.UnescapeString(builder.String())
+	text = strings.Map(func(r rune) rune {
+		switch r {
+		case '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff', '\u00ad', '\u034f':
+			return -1 // zero-width padding used to pad inbox preheaders
+		}
+		return r
+	}, text)
+
+	return strings.TrimSpace(text)
+}
+
+// skipRawTextElement reports the offset just past the closing tag of a <style>
+// or <script> element starting at i, whose contents are CDATA rather than text.
+func skipRawTextElement(lower string, i int) (int, bool) {
+	for _, name := range []string{"style", "script"} {
+		open := "<" + name
+		if !strings.HasPrefix(lower[i:], open) {
+			continue
+		}
+		// Guard against matching a prefix such as <styles-are-not-a-tag>.
+		if rest := lower[i+len(open):]; rest != "" && (isASCIILetter(rest[0]) || rest[0] == '-') {
+			continue
+		}
+		closing := "</" + name
+		if end := strings.Index(lower[i:], closing); end >= 0 {
+			after := i + end + len(closing)
+			if gt := strings.IndexByte(lower[after:], '>'); gt >= 0 {
+				return after + gt + 1, true
+			}
+			return len(lower), true
+		}
+		return len(lower), true // unterminated: the rest is not text
+	}
+	return 0, false
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 func createPreview(text string) string {


### PR DESCRIPTION
## Summary

`processMessage` never reversed `Content-Transfer-Encoding` and only looked at the top level of the MIME tree. Four ordinary message shapes read wrong or not at all. This replaces the two-case walk with a recursive `collectBodies()` and fixes the message-list preview, which had the matching problem.

## The bug that started this

Anthropic's *"Secure link to log in to Claude.ai"* mail does not render at all — the reading pane shows raw HTML source. Its structure is as plain as it gets:

```
* BODYSTRUCTURE ("TEXT" "HTML" ("CHARSET" "us-ascii") NIL NIL "QUOTED-PRINTABLE" 9684 194 NIL NIL NIL)
```

Single-part, `text/html`, quoted-printable. It falls into the non-multipart branch, which assigns **any** media type to `Email.Body`:

```go
} else {
    // Handle non-multipart messages
    bodyData, err := io.ReadAll(m.Body)
    if err == nil {
        email.Body = string(bodyData)
    }
}
```

`email-viewer.html` renders `{{if .Email.HTML}}` in the sandboxed iframe and otherwise falls back to `{{linkify .Email.Body}}`, so `Email.HTML` stays empty and the reader gets HTML source as plain text. The body is not transfer-decoded either, so it is littered with `=3D` and `=` soft line breaks.

## What's fixed

| | Bug | Symptom |
|---|---|---|
| 1 | Single-part `text/html` assigned to `Body`, not `HTML` | message renders as raw HTML source |
| 2 | `Content-Transfer-Encoding` never reversed | bodies show `5oiR5Lus…` (base64) or `=E2=80=94` (QP) |
| 3 | Multipart walk is one level deep | `multipart/mixed › multipart/alternative` renders **blank** |
| 4 | `Content-Disposition: attachment` not checked | a `text/plain` attachment replaces the body |

On (2): `mime/multipart` already decodes quoted-printable parts and strips the header, so in practice this recovers **base64** parts and **non-multipart** bodies, which `net/mail` hands back raw.

## Preview fixes

`stripHTML()` only removed tags, so a preview was usually the mail's CSS reset — literally `#outlook a { padding:0; }` — or base64 gibberish, or a stray `96` leaking out of `<o:PixelsPerInch>` inside an Outlook conditional comment. It now skips `<style>`/`<script>` elements and comments, resolves entities, and drops the zero-width characters senders pad preheaders with. The bytes are transfer-decoded before stripping.

`previewSection` grows `512` → `4096` bytes, because an HTML mail's opening `<style>` block routinely runs past the first kilobyte, leaving no prose in a shorter window.

That wider window introduces one subtlety worth calling out: it can overrun a part into the next MIME boundary, and `base64.DecodeString` then fails on the whole chunk and falls back to raw text. So base64 decoding stops at the first byte outside the alphabet (`base64PrefixLen`) and tolerates a trailing partial quantum. I hit this as a regression while verifying, not in theory — widening the window without it makes base64 previews *worse*, not better.

## Testing

- `handlers/api/collectbodies_test.go` — 10 cases covering each bug above, plus truncation tolerance, the `<styles-x>` lookalike-tag guard, and the boundary-overrun case.
- `go test ./...` passes (7 packages); `go vet ./handlers/api/` clean.
- Verified end-to-end against a live Gmail IMAP mailbox over `/v1/messages/:uid`: the Anthropic message goes from `html len 0 / body len 9684 (raw source)` to `html len 8992 / body len 0`, no `=3D` residue, magic link intact, and it renders in the iframe. Chinese base64 previews (Google Play, Cloudflare) decode correctly instead of showing `5oiR5Lus…`.

## Notes

- No new dependencies; `encoding/base64`, `mime/quotedprintable` and `html` are already in use or stdlib.
- Charset conversion is deliberately **out of scope** — a `gbk`-encoded body will still be mojibake. That needs `x/net/html/charset` and is a separate change.
- I noticed #7 touched adjacent ground and was closed; this PR does not add endpoints or touch attachment download. It is confined to body parsing and preview text.

## GenAI disclosure

Per the project's AI Assistance Policy: the diagnosis, patch, and tests were produced with Claude Code (Claude Opus 4.8) under my direction, and verified against a live Gmail mailbox before submission. I have reviewed the change and am accountable for its correctness, originality, and license compatibility.
